### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@ $ git clone git@github.com:Tom-Shorter/autoCORPus.git
 
 $ cd autoCORPus
 
-$ python3 -m venv env
+$ python3 -m venv env or (for Windows users) py -[v] -m venv env (where v is the version of Python used)
 
-$ source env/bin/activate
+$ source env/bin/activate or (for Windows users) path/to/env/Scripts/activate.bat
 
 $ pip install .
 
 You might get an error here `ModuleNotFoundError: No module named 'skbuild'` if you do then run 
 $ pip install --upgrade pip 
+or might need to install the Microsoft Build Tools for Visual Studio 
+(see https://www.scivision.dev/python-windows-visual-c-14-required for minimal installation requirements so that python-Levenshtein package can be installed)
 first and then re run 
 $ pip install .
 


### PR DESCRIPTION
As the operating system installed on my computer is Windows (10), I have identified alternatives to the commands which do not exist on Windows. 
Additionally, the command pip install . generated another error for me concerning the installation of the python-Levenshtein package.