### PR TITLE
Update config_pmc.json

### DIFF
--- a/configs/config_pmc.json
+++ b/configs/config_pmc.json
@@ -66,7 +66,7 @@
         "regex":[
             {
                 "attrs": "id",
-                "regex": "^_*[pP]\\d+$"
+                "regex": "^(_*[pP]\\d+)|(Par\\d+)$"
             }
         ]
 


### PR DESCRIPTION
Some papers follow a different pattern for the paragraph id, so I added it as an alternative to "regex", and now it works for them as well.